### PR TITLE
Cairo contracts

### DIFF
--- a/contracts/eip712.cairo
+++ b/contracts/eip712.cairo
@@ -1,0 +1,79 @@
+%lang starknet
+
+from starkware.cairo.common.alloc import alloc
+from starkware.cairo.common.math import split_felt
+from starkware.cairo.common.uint256 import Uint256
+from starkware.cairo.common.cairo_builtins import BitwiseBuiltin
+from starkware.cairo.common.bitwise import bitwise_and
+from contracts.keccak256 import uint256_keccak
+
+func fill_with_uint256{range_check_ptr}(result : Uint256*, values : felt*, values_len : felt) -> ():
+    if values_len == 0:
+        return ()
+    end
+
+    let (high, low) = split_felt([values])
+    assert result[0] = Uint256(low, high)
+    fill_with_uint256(result + 2, values + 1, values_len - 1)
+    return ()
+end
+
+func map_to_uint256{range_check_ptr}(values : felt*, values_len : felt) -> (result : Uint256*):
+    alloc_locals
+    let (result : Uint256*) = alloc()
+    fill_with_uint256(result, values, values_len)
+    return (result)
+end
+
+const PREFIX = 0x1901
+# Has to be recalculated when type is changed with Payload.type_hash()
+const TYPE_HASH_HIGH = 0x71430fb281ccdfae35ad0b5d5279034e
+const TYPE_HASH_LOW = 0x04e1e56c77b10d30506aad6cad95206f
+# Has to be recalculated when type is changed with adapter_domain.hash_struct()
+const DOMAIN_SEP_HIGH = 0x91ad78de7411f710180a9a7d63d190f2
+const DOMAIN_SEP_LOW = 0xbb5962361c7beb5df697fb012e216fdd
+
+# value has to be a 16 byte word
+# prefix length = PREFIX_BITS
+func add_prefix{range_check_ptr, bitwise_ptr : BitwiseBuiltin*}(value : felt, prefix : felt) -> (
+        result : felt, overflow):
+    let shifted_prefix = prefix * 2 ** 128
+    # with_prefix is 18 bytes long
+    let with_prefix = shifted_prefix + value
+    let overflow_mask = 2 ** 16 - 1
+    let (overflow) = bitwise_and(with_prefix, overflow_mask)
+    let result = (with_prefix - overflow) / 2 ** 16
+    return (result, overflow)
+end
+
+func get_hash{range_check_ptr, bitwise_ptr : BitwiseBuiltin*}(
+        to : felt, selector : felt, calldata_len : felt, calldata : felt*, nonce : felt) -> (
+        hashed_msg : Uint256):
+    alloc_locals
+    let (calldata_uint256) = map_to_uint256(calldata, calldata_len)
+    let (calldata_hash) = uint256_keccak(calldata_uint256, calldata_len * 32)
+
+    let (nonce_h, nonce_l) = split_felt(nonce)
+    let (to_h, to_l) = split_felt(to)
+    let (selector_h, selector_l) = split_felt(selector)
+
+    let (encoded_data : Uint256*) = alloc()
+    assert encoded_data[0] = Uint256(TYPE_HASH_LOW, TYPE_HASH_HIGH)
+    assert encoded_data[1] = Uint256(nonce_l, nonce_h)
+    assert encoded_data[2] = Uint256(to_l, to_h)
+    assert encoded_data[3] = Uint256(selector_l, selector_h)
+    assert encoded_data[4] = Uint256(calldata_hash.low, calldata_hash.high)
+    let (data_hash) = uint256_keccak(encoded_data, 5 * 32)
+
+    let prefix = PREFIX
+    let (w1, prefix) = add_prefix(DOMAIN_SEP_HIGH, prefix)
+    let (w0, prefix) = add_prefix(DOMAIN_SEP_LOW, prefix)
+    let (w3, prefix) = add_prefix(data_hash.high, prefix)
+    let (w2, overflow) = add_prefix(data_hash.low, prefix)
+    let (signable_bytes : Uint256*) = alloc()
+    assert signable_bytes[0] = Uint256(w0, w1)
+    assert signable_bytes[1] = Uint256(w2, w3)
+    assert signable_bytes[2] = Uint256(overflow, 0)
+    let (res) = uint256_keccak(signable_bytes, 32 + 32 + 2)
+    return (res)
+end

--- a/contracts/keccak256.cairo
+++ b/contracts/keccak256.cairo
@@ -1,0 +1,156 @@
+%lang starknet
+# %builtins pedersen range_check ecdsa bitwise
+
+from keccak import keccak256
+from starkware.cairo.common.alloc import alloc
+from starkware.cairo.common.cairo_builtins import BitwiseBuiltin
+from starkware.cairo.common.bitwise import bitwise_and
+from starkware.cairo.common.math import split_felt, unsigned_div_rem, assert_le, assert_in_range
+from starkware.cairo.common.math_cmp import is_nn, is_le
+from starkware.cairo.common.uint256 import Uint256
+from starkware.cairo.common.pow import pow
+
+func mask{range_check_ptr, bitwise_ptr : BitwiseBuiltin*}(value, byte_index, bytes_len) -> (
+        result : felt):
+    alloc_locals
+
+    let start_bit = byte_index * 8
+    let end_bit = start_bit + bytes_len * 8
+
+    # mask = 2 ^ (end_bit) - 2 ^ (start_bit)
+    let (mask_sub) = pow(2, start_bit)
+    let (mask) = pow(2, end_bit)
+    let mask = mask - mask_sub
+
+    let (result) = bitwise_and(value, mask)
+    return (result)
+end
+
+func move_left{range_check_ptr, bitwise_ptr : BitwiseBuiltin*}(value, byte_index, bytes) -> (
+        result : felt):
+    alloc_locals
+    let (masked) = mask(value, byte_index, 1)
+    let (shift) = pow(2, bytes * 8)
+    let shifted = masked * shift
+    return (shifted)
+end
+
+func move_right{range_check_ptr, bitwise_ptr : BitwiseBuiltin*}(value, byte_index, bytes) -> (
+        result : felt):
+    alloc_locals
+    let (masked) = mask(value, byte_index, 1)
+    let (shift) = pow(2, bytes * 8)
+    let shifted = masked / shift
+    return (shifted)
+end
+
+func reverse_bytes{range_check_ptr, bitwise_ptr : BitwiseBuiltin*}(value : felt) -> (result : felt):
+    alloc_locals
+    let (l0) = move_left(value, 0, 7)
+    let (l1) = move_left(value, 1, 5)
+    let (l2) = move_left(value, 2, 3)
+    let (l3) = move_left(value, 3, 1)
+    let (l4) = move_right(value, 4, 1)
+    let (l5) = move_right(value, 5, 3)
+    let (l6) = move_right(value, 6, 5)
+    let (l7) = move_right(value, 7, 7)
+    let result = l0 + l1 + l2 + l3 + l4 + l5 + l6 + l7
+    return (result)
+end
+
+func keccak_result_to_uint256{range_check_ptr, bitwise_ptr : BitwiseBuiltin*}(
+        r0 : felt, r1 : felt, r2 : felt, r3 : felt) -> (res : Uint256):
+    alloc_locals
+    # little to big endian
+    let (reversed0) = reverse_bytes(r0)
+    let (reversed1) = reverse_bytes(r1)
+    let (reversed2) = reverse_bytes(r2)
+    let (reversed3) = reverse_bytes(r3)
+
+    let low = reversed3 + reversed2 * 2 ** 64
+    let high = reversed1 + reversed0 * 2 ** 64
+
+    return (Uint256(low, high))
+end
+
+func split_uint256{range_check_ptr, bitwise_ptr : BitwiseBuiltin*}(value : Uint256) -> (
+        res0 : felt, res1 : felt, res2 : felt, res3 : felt):
+    alloc_locals
+    local first_mask = 2 ** 64 - 1
+    local second_mask = 2 ** 128 - 1 - first_mask
+    local second_shift = 2 ** 64
+
+    let (r0) = bitwise_and(value.low, first_mask)
+
+    let (second_masked) = bitwise_and(value.low, second_mask)
+    let r1 = second_masked / second_shift
+
+    let (r2) = bitwise_and(value.high, first_mask)
+
+    let (fourth_masked) = bitwise_and(value.high, second_mask)
+    let r3 = fourth_masked / second_shift
+
+    return (r0, r1, r2, r3)
+end
+
+func split_uint256_array{range_check_ptr, bitwise_ptr : BitwiseBuiltin*}(
+        values_len : felt, values : Uint256*, result : felt*) -> (res : felt*):
+    alloc_locals
+    if values_len == 0:
+        return (result)
+    end
+
+    let value = [values]
+    let (r0, r1, r2, r3) = split_uint256(value)
+    # To little endian
+    let (le0) = reverse_bytes(r0)
+    let (le1) = reverse_bytes(r1)
+    let (le2) = reverse_bytes(r2)
+    let (le3) = reverse_bytes(r3)
+
+    assert result[0] = le3
+    assert result[1] = le2
+    assert result[2] = le1
+    assert result[3] = le0
+
+    split_uint256_array(values_len - 1, values + 2, result + 4)
+    return (result)
+end
+
+# Handles additional 2 bytes is were provided
+func handle_leftover{range_check_ptr, bitwise_ptr : BitwiseBuiltin*}(
+        uint256_count : felt, rem_bytes : felt, values : Uint256*, inputs : felt*) -> ():
+    alloc_locals
+    if rem_bytes == 0:
+        return ()
+    end
+
+    if rem_bytes != 2:
+        assert 1 = 0
+    end
+
+    let value = values[uint256_count]
+    let (new_0) = move_right(value.low, 1, 1)
+    let (new_1) = move_left(value.low, 0, 1)
+    let new_value = new_0 + new_1
+    let target_index = uint256_count * 4
+    assert inputs[target_index] = new_value
+    return ()
+end
+
+# Supports bytes = 32*n + k, where k = 0 or k = 2 and n >= 0
+func uint256_keccak{range_check_ptr, bitwise_ptr : BitwiseBuiltin*}(
+        values : Uint256*, bytes : felt) -> (res : Uint256):
+    alloc_locals
+    let (uint256_count, rem_bytes) = unsigned_div_rem(bytes, 32)
+    let (inputs : felt*) = alloc()
+    split_uint256_array(uint256_count, values, inputs)
+    handle_leftover(uint256_count, rem_bytes, values, inputs)
+
+    let (local keccak_ptr_start : felt*) = alloc()
+    let keccak_ptr = keccak_ptr_start
+    let (local output : felt*) = keccak256{keccak_ptr=keccak_ptr}(inputs, bytes)
+
+    let (res) = keccak_result_to_uint256(output[0], output[1], output[2], output[3])
+    return (res)
+end

--- a/contracts/recover.cairo
+++ b/contracts/recover.cairo
@@ -1,0 +1,312 @@
+%lang starknet
+
+from contracts.secp.bigint import BigInt3, UnreducedBigInt5, nondet_bigint3, bigint_mul, BASE
+from contracts.secp.secp import mul_s_inv
+from contracts.secp.secp_ec import EcPoint, ec_mul, ec_add
+from starkware.cairo.common.math import assert_in_range, assert_not_equal, assert_not_zero
+from starkware.cairo.common.cairo_builtins import BitwiseBuiltin
+from starkware.cairo.common.bitwise import bitwise_and, bitwise_xor, bitwise_or
+from starkware.cairo.common.uint256 import Uint256, uint256_sub
+from starkware.cairo.common.alloc import alloc
+from contracts.keccak256 import uint256_keccak
+
+# Performs (a * b) % m and returns normalized BigInt3
+func mul_mod{range_check_ptr}(a : BigInt3, b : BigInt3, m : BigInt3) -> (res : BigInt3):
+    %{
+        from starkware.cairo.common.cairo_secp.secp_utils import pack
+        from starkware.python.math_utils import div_mod, safe_div
+
+        a = pack(ids.a, PRIME)
+        b = pack(ids.b, PRIME)
+        product = a * b
+        m = pack(ids.m, PRIME)
+
+        value = res = product % m
+    %}
+    let (res) = nondet_bigint3()
+
+    %{ value = k = product // m %}
+    let (k) = nondet_bigint3()
+    let (k_m) = bigint_mul(k, m)
+    let (multiplied) = bigint_mul(a, b)
+
+    # We need to verify that multiplied = k_m + res
+
+    tempvar carry1 = (multiplied.d0 - k_m.d0 - res.d0) / BASE
+    assert [range_check_ptr + 0] = carry1 + 2 ** 127
+
+    tempvar carry2 = (multiplied.d1 - k_m.d1 - res.d1 + carry1) / BASE
+    assert [range_check_ptr + 1] = carry2 + 2 ** 127
+
+    tempvar carry3 = (multiplied.d2 - k_m.d2 - res.d2 + carry2) / BASE
+    assert [range_check_ptr + 2] = carry3 + 2 ** 127
+
+    tempvar carry4 = (multiplied.d3 - k_m.d3 + carry3) / BASE
+    assert [range_check_ptr + 3] = carry4 + 2 ** 127
+
+    assert multiplied.d4 - k_m.d4 + carry4 = 0
+
+    let range_check_ptr = range_check_ptr + 4
+
+    return (res)
+end
+
+# Performs (a - b) % m and returns normalized BigInt3
+func bigint3_sub{range_check_ptr}(a : BigInt3, b : BigInt3) -> (res : BigInt3):
+    %{
+        from starkware.cairo.common.cairo_secp.secp_utils import pack
+        from starkware.python.math_utils import div_mod, safe_div
+
+        a = pack(ids.a, PRIME)
+        b = pack(ids.b, PRIME)
+
+        value = res = a - b
+    %}
+    let (res) = nondet_bigint3()
+
+    let s_0 = res.d0 + b.d0
+    let s_1 = res.d1 + b.d1
+    let s_2 = res.d2 + b.d2
+    # We need to prove that a = res + b
+
+    tempvar carry1 = (a.d0 - res.d0 - b.d0) / BASE
+    assert [range_check_ptr + 0] = carry1 + 2 ** 127
+
+    tempvar carry2 = (a.d1 - res.d1 - b.d1 + carry1) / BASE
+    assert [range_check_ptr + 1] = carry2 + 2 ** 127
+
+    assert a.d2 - res.d2 - b.d2 + carry2 = 0
+
+    let range_check_ptr = range_check_ptr + 2
+
+    return (res=res)
+end
+
+# Performs a % m and returns normalized BigInt3
+func mod{range_check_ptr}(a : BigInt3, m : BigInt3) -> (res : BigInt3):
+    let one = BigInt3(1, 0, 0)
+    let (result) = mul_mod(a, one, m)
+    return (result)
+end
+
+func add_mod{range_check_ptr}(a : BigInt3, b : BigInt3, m : BigInt3) -> (res : BigInt3):
+    let s_0 = a.d0 + b.d0
+    let s_1 = a.d1 + b.d1
+    let s_2 = a.d2 + b.d2
+    let sum = BigInt3(s_0, s_1, s_2)
+    # This works because mod normalizes BigInt3
+    let (res) = mod(sum, m)
+
+    return (res)
+end
+
+# Performs (a ** p) % m
+func pow_mod{range_check_ptr, bitwise_ptr : BitwiseBuiltin*}(
+        a : BigInt3, p : BigInt3, m : BigInt3) -> (res : BigInt3):
+    alloc_locals
+    # p == 1
+    if p.d0 == 1:
+        if p.d1 == 0:
+            if p.d2 == 0:
+                let (res) = mul_mod(a, p, m)
+                return (res)
+            end
+        end
+    end
+
+    let (is_odd) = bitwise_and(p.d0, 1)
+    if is_odd == 1:
+        let one = BigInt3(1, 0, 0)
+        let (new_p) = bigint3_sub(p, one)
+        let (rest) = pow_mod(a, new_p, m)
+        let (res) = mul_mod(a, rest, m)
+        return (res)
+    end
+
+    let two = BigInt3(2, 0, 0)
+    let (half_p) = mul_s_inv(p, two, m)
+    let (multiplier) = pow_mod(a, half_p, m)
+    let (res) = mul_mod(multiplier, multiplier, m)
+    return (res)
+end
+
+const A = 0
+
+# B = 7
+const B_0 = 7
+const B_1 = 0
+const B_2 = 0
+
+# P = 2**256 - 2**32 - 97
+const P_0 = 0x3ffffffffffffefffffc2f
+const P_1 = 0x3fffffffffffffffffffff
+const P_2 = 0xfffffffffffffffffffff
+
+# PD = (P + 1) // 4
+const PD_0 = 0x3fffffffffffffbfffff0c
+const PD_1 = 0x3fffffffffffffffffffff
+const PD_2 = 0x3ffffffffffffffffffff
+
+# GX = 55066263022277343669578718895168534326250603453777594175500187360389116729240
+const GX_0 = 0xe28d959f2815b16f81798
+const GX_1 = 0xa573a1c2c1c0a6ff36cb7
+const GX_2 = 0x79be667ef9dcbbac55a06
+
+# GY = 32670510020758816978083085130507043184471273380659243275938904335757337482424
+const GY_0 = 0x554199c47d08ffb10d4b8
+const GY_1 = 0x2ff0384422a3f45ed1229a
+const GY_2 = 0x483ada7726a3c4655da4f
+
+# N = 115792089237316195423570985008687907852837564279074904382605163141518161494337
+const N_0 = 0x8a03bbfd25e8cd0364141
+const N_1 = 0x3ffffffffffaeabb739abd
+const N_2 = 0xfffffffffffffffffffff
+
+# (xcubedaxb - y * y) % P = 0
+func assert_y_ok{range_check_ptr, bitwise_ptr : BitwiseBuiltin*}(y : BigInt3, xcubedaxb : BigInt3) -> ():
+    alloc_locals
+    let P = BigInt3(P_0, P_1, P_2)
+    let two = BigInt3(2, 0, 0)
+    let (y_sq) = pow_mod(y, two, P)
+    let (xmod) = mod(xcubedaxb, P)
+    assert y_sq.d0 = xmod.d0
+    assert y_sq.d1 = xmod.d1
+    assert y_sq.d2 = xmod.d2
+    return ()
+end
+
+# (s % N) != 0
+func assert_not_N_multiplication{range_check_ptr}(value : BigInt3) -> ():
+    alloc_locals
+    let N = BigInt3(N_0, N_1, N_2)
+    let (result) = mod(value, N)
+    if result.d0 == 0:
+        if result.d1 == 0:
+            if result.d2 == 0:
+                # Result is 0, fail
+                assert 1 = 0
+            end
+        end
+    end
+
+    return ()
+end
+
+func calc_y{range_check_ptr, bitwise_ptr : BitwiseBuiltin*}(v : felt, x : BigInt3) -> (y : BigInt3):
+    alloc_locals
+    let P = BigInt3(P_0, P_1, P_2)
+    let PD = BigInt3(PD_0, PD_1, PD_2)
+    let B = BigInt3(B_0, B_1, B_2)
+
+    let (xcubedaxb) = mul_mod(x, x, P)
+    let (xcubedaxb) = mul_mod(xcubedaxb, x, P)
+    let (xcubedaxb) = add_mod(xcubedaxb, B, P)
+    let (beta) = pow_mod(xcubedaxb, PD, P)
+
+    # use_beta = (v % 2) ^ (beta % 2)
+    let (v_mod_2) = bitwise_and(v, 1)
+    let (beta_mod_2) = bitwise_and(beta.d0, 1)
+    let (use_beta) = bitwise_xor(v_mod_2, beta_mod_2)
+
+    if use_beta == 1:
+        assert_y_ok(beta, xcubedaxb)
+        return (beta)
+    end
+
+    let (y) = bigint3_sub(P, beta)
+    assert_y_ok(y, xcubedaxb)
+    return (y)
+end
+
+func ecdsa_raw_recover{range_check_ptr, bitwise_ptr : BitwiseBuiltin*}(
+        hash : BigInt3, v : felt, r : BigInt3, s : BigInt3) -> (res : EcPoint):
+    alloc_locals
+
+    assert_not_N_multiplication(r)
+    assert_not_N_multiplication(s)
+
+    let P = BigInt3(P_0, P_1, P_2)
+    let G = EcPoint(BigInt3(GX_0, GX_1, GX_2), BigInt3(GY_0, GY_1, GY_2))
+    let N = BigInt3(N_0, N_1, N_2)
+
+    let v = v + 27
+    assert_in_range(v, 27, 34)
+
+    let x = r
+    let (y) = calc_y(v, x)
+    let z = hash
+
+    let R = EcPoint(x, y)
+    # u1 = -z/r mod N
+    let (u1) = mul_s_inv(z, r, N)
+    let (u1) = bigint3_sub(N, u1)
+    # u2 = s/r mod N
+    let (u2) = mul_s_inv(s, r, N)
+
+    let (first) = ec_mul(G, u1)
+    let R = EcPoint(x, y)
+    let (second) = ec_mul(R, u2)
+    let (res) = ec_add(first, second)
+
+    return (res)
+end
+
+func bigint3_to_uint256{range_check_ptr, bitwise_ptr : BitwiseBuiltin*}(value : BigInt3) -> (
+        res : Uint256):
+    assert_in_range(value.d0, 0, BASE)
+    assert_in_range(value.d1, 0, BASE)
+    assert_in_range(value.d2, 0, BASE)
+
+    # 128-86 = 42
+    let low_d1_mask = 2 ** 42 - 1
+    let (low_d1) = bitwise_and(value.d1, low_d1_mask)
+    let low = value.d0 + low_d1 * BASE
+
+    let high_d1_shift = 2 ** 42
+    let high_d1 = (value.d1 - low_d1) / high_d1_shift
+    let shift = 2 ** 44
+    let high = value.d2 * shift + high_d1
+
+    return (Uint256(low, high))
+end
+
+func uint256_to_bigint3{range_check_ptr, bitwise_ptr : BitwiseBuiltin*}(value : Uint256) -> (
+        res : BigInt3):
+    assert_in_range(value.low, 0, 2 ** 128)
+    assert_in_range(value.high, 0, 2 ** 128)
+
+    let d0_mask = 2 ** 86 - 1
+    let (d0) = bitwise_and(value.low, d0_mask)
+
+    let d1_low = (value.low - d0) / 2 ** 86
+    let d1_mask = 2 ** 44 - 1
+    let (d1_high_masked) = bitwise_and(value.high, d1_mask)
+    let d1_high = d1_high_masked * 2 ** 42
+    let d1 = d1_low + d1_high
+
+    let d2 = (value.high - d1_high_masked) / 2 ** 44
+    return (BigInt3(d0, d1, d2))
+end
+
+func calc_eth_address{range_check_ptr, bitwise_ptr : BitwiseBuiltin*}(
+        hash : Uint256, v : felt, r : Uint256, s : Uint256) -> (address : felt):
+    alloc_locals
+
+    let (hash_bigint3) = uint256_to_bigint3(hash)
+    let (r_bigint3) = uint256_to_bigint3(r)
+    let (s_bigint3) = uint256_to_bigint3(s)
+    let (public_key) = ecdsa_raw_recover(hash_bigint3, v, r_bigint3, s_bigint3)
+
+    let (x) = bigint3_to_uint256(public_key.x)
+    let (y) = bigint3_to_uint256(public_key.y)
+    let (inputs : Uint256*) = alloc()
+    assert inputs[0] = x
+    assert inputs[1] = y
+    let (hashed) = uint256_keccak(inputs, 32 + 32)
+
+    # Eth address is just lower 20 bytes of keccak(public_key)
+    let high_mask = 2 ** 32 - 1
+    let (high_part) = bitwise_and(high_mask, hashed.high)
+    let address = high_part * 2 ** 128 + hashed.low
+    return (address)
+end

--- a/contracts/secp/bigint.cairo
+++ b/contracts/secp/bigint.cairo
@@ -1,0 +1,69 @@
+# The base of the representation.
+const BASE = 2 ** 86
+
+# Represents an integer defined by
+#   d0 + BASE * d1 + BASE**2 * d2.
+# Note that the limbs (d_i) are NOT restricted to the range [0, BASE) and in particular they
+# can be negative.
+# In most cases this is used to represent a secp256k1 field element.
+struct UnreducedBigInt3:
+    member d0 : felt
+    member d1 : felt
+    member d2 : felt
+end
+
+# Same as UnreducedBigInt3, except that d0, d1 and d2 must be in the range [0, 3 * BASE).
+# In most cases this is used to represent a secp256k1 field element.
+struct BigInt3:
+    member d0 : felt
+    member d1 : felt
+    member d2 : felt
+end
+
+# Represents a big integer: sum_i(BASE**i * d_i).
+# Note that the limbs (d_i) are NOT restricted to the range [0, BASE) and in particular they
+# can be negative.
+struct UnreducedBigInt5:
+    member d0 : felt
+    member d1 : felt
+    member d2 : felt
+    member d3 : felt
+    member d4 : felt
+end
+
+func bigint_mul(x : BigInt3, y : BigInt3) -> (res : UnreducedBigInt5):
+    return (
+        UnreducedBigInt5(
+        d0=x.d0 * y.d0,
+        d1=x.d0 * y.d1 + x.d1 * y.d0,
+        d2=x.d0 * y.d2 + x.d1 * y.d1 + x.d2 * y.d0,
+        d3=x.d1 * y.d2 + x.d2 * y.d1,
+        d4=x.d2 * y.d2))
+end
+
+# Returns a BigInt3 instance whose value is controlled by a prover hint.
+#
+# Soundness guarantee: each limb is in the range [0, 3 * BASE).
+# Completeness guarantee (honest prover): the value is in reduced form and in particular,
+# each limb is in the range [0, BASE).
+#
+# Hint arguments: value.
+func nondet_bigint3{range_check_ptr}() -> (res : BigInt3):
+    # The result should be at the end of the stack after the function returns.
+    let res : BigInt3 = [cast(ap + 5, BigInt3*)]
+    %{
+        from starkware.cairo.common.cairo_secp.secp_utils import split
+        segments.write_arg(ids.res.address_, split(value))
+    %}
+    # The maximal possible sum of the limbs, assuming each of them is in the range [0, BASE).
+    const MAX_SUM = 3 * (BASE - 1)
+    assert [range_check_ptr] = MAX_SUM - (res.d0 + res.d1 + res.d2)
+
+    # Prepare the result at the end of the stack.
+    tempvar range_check_ptr = range_check_ptr + 4
+    [range_check_ptr - 3] = res.d0; ap++
+    [range_check_ptr - 2] = res.d1; ap++
+    [range_check_ptr - 1] = res.d2; ap++
+    static_assert &res + BigInt3.SIZE == ap
+    return (res=res)
+end

--- a/contracts/secp/secp.cairo
+++ b/contracts/secp/secp.cairo
@@ -1,0 +1,81 @@
+# Implementation of the ECDSA signature verification over the secp256k1 elliptic curve.
+# See information on the curve in secp_def.cairo.
+#
+# The generator point for the ECDSA is:
+#   G = (
+#       0x79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798,
+#       0x483ada7726a3c4655da4fbfc0e1108a8fd17b448a68554199c47d08ffb10d4b8
+#   )
+
+from contracts.secp.bigint import BASE, BigInt3, bigint_mul, nondet_bigint3
+from contracts.secp.secp_def import N0, N1, N2
+from contracts.secp.secp_ec import EcPoint, ec_add, ec_mul
+
+from starkware.cairo.common.math import assert_nn_le, assert_not_zero
+
+# Computes x * s^(-1) modulo n
+# This is the only modified file from cairo examples
+func mul_s_inv{range_check_ptr}(x : BigInt3, s : BigInt3, n: BigInt3) -> (res : BigInt3):
+    %{
+        from starkware.cairo.common.cairo_secp.secp_utils import pack
+        from starkware.python.math_utils import div_mod, safe_div
+
+        N = pack(ids.n, PRIME)
+        x = pack(ids.x, PRIME) % N
+        s = pack(ids.s, PRIME) % N
+        value = res = div_mod(x, s, N)
+    %}
+    let (res) = nondet_bigint3()
+
+    %{ value = k = safe_div(res * s - x, N) %}
+    let (k) = nondet_bigint3()
+
+    let (res_s) = bigint_mul(res, s)
+    let (k_n) = bigint_mul(k, n)
+
+    # We should now have res_s = k_n + x. Since the numbers are in unreduced form,
+    # we should handle the carry.
+
+    tempvar carry1 = (res_s.d0 - k_n.d0 - x.d0) / BASE
+    assert [range_check_ptr + 0] = carry1 + 2 ** 127
+
+    tempvar carry2 = (res_s.d1 - k_n.d1 - x.d1 + carry1) / BASE
+    assert [range_check_ptr + 1] = carry2 + 2 ** 127
+
+    tempvar carry3 = (res_s.d2 - k_n.d2 - x.d2 + carry2) / BASE
+    assert [range_check_ptr + 2] = carry3 + 2 ** 127
+
+    tempvar carry4 = (res_s.d3 - k_n.d3 + carry3) / BASE
+    assert [range_check_ptr + 3] = carry4 + 2 ** 127
+
+    assert res_s.d4 - k_n.d4 + carry4 = 0
+
+    let range_check_ptr = range_check_ptr + 4
+
+    return (res=res)
+end
+
+# Verifies that val is in the range [1, N).
+func validate_signature_entry{range_check_ptr}(val : BigInt3):
+    assert_nn_le(val.d2, N2)
+    assert_nn_le(val.d1, BASE - 1)
+    assert_nn_le(val.d0, BASE - 1)
+
+    if val.d2 == N2:
+        if val.d1 == N1:
+            assert_nn_le(val.d0, N0 - 1)
+            return ()
+        end
+        assert_nn_le(val.d1, N1 - 1)
+        return ()
+    end
+
+    if val.d2 == 0:
+        if val.d1 == 0:
+            # Make sure val > 0.
+            assert_not_zero(val.d0)
+            return ()
+        end
+    end
+    return ()
+end

--- a/contracts/secp/secp_def.cairo
+++ b/contracts/secp/secp_def.cairo
@@ -1,0 +1,17 @@
+# Basic definitions for the secp256k1 elliptic curve.
+# The curve is given by the equation
+#   y^2 = x^3 + 7
+# over the field Z/p for
+#   p = secp256k1_prime = 2 ** 256 - (2 ** 32 + 2 ** 9 + 2 ** 8 + 2 ** 7 + 2 ** 6 + 2 ** 4 + 1).
+# The size of the curve is
+#   n = 0xfffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141 (prime).
+
+# SECP_REM is defined by the equation:
+#   secp256k1_prime = 2 ** 256 - SECP_REM.
+const SECP_REM = 2 ** 32 + 2 ** 9 + 2 ** 8 + 2 ** 7 + 2 ** 6 + 2 ** 4 + 1
+
+# The following constants represent the size of the secp256k1 curve:
+#   n = N0 + BASE * N1 + BASE**2 * N2.
+const N0 = 0x8a03bbfd25e8cd0364141
+const N1 = 0x3ffffffffffaeabb739abd
+const N2 = 0xfffffffffffffffffffff

--- a/contracts/secp/secp_ec.cairo
+++ b/contracts/secp/secp_ec.cairo
@@ -1,0 +1,230 @@
+from contracts.secp.bigint import BigInt3, UnreducedBigInt3, nondet_bigint3
+from contracts.secp.secp_field import is_zero, unreduced_mul, unreduced_sqr, verify_zero
+
+# Represents a point on the elliptic curve.
+# The zero point is represented using pt.x=0, as there is no point on the curve with this x value.
+struct EcPoint:
+    member x : BigInt3
+    member y : BigInt3
+end
+
+# Returns the slope of the elliptic curve at the given point.
+# The slope is used to compute pt + pt.
+# Assumption: pt != 0.
+func compute_doubling_slope{range_check_ptr}(pt : EcPoint) -> (slope : BigInt3):
+    # Note that y cannot be zero: assume that it is, then pt = -pt, so 2 * pt = 0, which
+    # contradicts the fact that the size of the curve is odd.
+    %{
+        from starkware.cairo.common.cairo_secp.secp_utils import SECP_P, pack
+        from starkware.python.math_utils import div_mod
+
+        # Compute the slope.
+        x = pack(ids.pt.x, PRIME)
+        y = pack(ids.pt.y, PRIME)
+        value = slope = div_mod(3 * x ** 2, 2 * y, SECP_P)
+    %}
+    let (slope : BigInt3) = nondet_bigint3()
+
+    let (x_sqr : UnreducedBigInt3) = unreduced_sqr(pt.x)
+    let (slope_y : UnreducedBigInt3) = unreduced_mul(slope, pt.y)
+
+    verify_zero(
+        UnreducedBigInt3(
+        d0=3 * x_sqr.d0 - 2 * slope_y.d0,
+        d1=3 * x_sqr.d1 - 2 * slope_y.d1,
+        d2=3 * x_sqr.d2 - 2 * slope_y.d2))
+
+    return (slope=slope)
+end
+
+# Returns the slope of the line connecting the two given points.
+# The slope is used to compute pt0 + pt1.
+# Assumption: pt0.x != pt1.x (mod secp256k1_prime).
+func compute_slope{range_check_ptr}(pt0 : EcPoint, pt1 : EcPoint) -> (slope : BigInt3):
+    %{
+        from starkware.cairo.common.cairo_secp.secp_utils import SECP_P, pack
+        from starkware.python.math_utils import div_mod
+
+        # Compute the slope.
+        x0 = pack(ids.pt0.x, PRIME)
+        y0 = pack(ids.pt0.y, PRIME)
+        x1 = pack(ids.pt1.x, PRIME)
+        y1 = pack(ids.pt1.y, PRIME)
+        value = slope = div_mod(y0 - y1, x0 - x1, SECP_P)
+    %}
+    let (slope) = nondet_bigint3()
+
+    let x_diff = BigInt3(d0=pt0.x.d0 - pt1.x.d0, d1=pt0.x.d1 - pt1.x.d1, d2=pt0.x.d2 - pt1.x.d2)
+    let (x_diff_slope : UnreducedBigInt3) = unreduced_mul(x_diff, slope)
+
+    verify_zero(
+        UnreducedBigInt3(
+        d0=x_diff_slope.d0 - pt0.y.d0 + pt1.y.d0,
+        d1=x_diff_slope.d1 - pt0.y.d1 + pt1.y.d1,
+        d2=x_diff_slope.d2 - pt0.y.d2 + pt1.y.d2))
+
+    return (slope)
+end
+
+# Given a point 'pt' on the elliptic curve, computes pt + pt.
+func ec_double{range_check_ptr}(pt : EcPoint) -> (res : EcPoint):
+    if pt.x.d0 == 0:
+        if pt.x.d1 == 0:
+            if pt.x.d2 == 0:
+                return (pt)
+            end
+        end
+    end
+
+    let (slope : BigInt3) = compute_doubling_slope(pt)
+    let (slope_sqr : UnreducedBigInt3) = unreduced_sqr(slope)
+
+    %{
+        from starkware.cairo.common.cairo_secp.secp_utils import SECP_P, pack
+
+        slope = pack(ids.slope, PRIME)
+        x = pack(ids.pt.x, PRIME)
+        y = pack(ids.pt.y, PRIME)
+
+        value = new_x = (pow(slope, 2, SECP_P) - 2 * x) % SECP_P
+    %}
+    let (new_x : BigInt3) = nondet_bigint3()
+
+    %{ value = new_y = (slope * (x - new_x) - y) % SECP_P %}
+    let (new_y : BigInt3) = nondet_bigint3()
+
+    verify_zero(
+        UnreducedBigInt3(
+        d0=slope_sqr.d0 - new_x.d0 - 2 * pt.x.d0,
+        d1=slope_sqr.d1 - new_x.d1 - 2 * pt.x.d1,
+        d2=slope_sqr.d2 - new_x.d2 - 2 * pt.x.d2))
+
+    let (x_diff_slope : UnreducedBigInt3) = unreduced_mul(
+        BigInt3(d0=pt.x.d0 - new_x.d0, d1=pt.x.d1 - new_x.d1, d2=pt.x.d2 - new_x.d2), slope)
+
+    verify_zero(
+        UnreducedBigInt3(
+        d0=x_diff_slope.d0 - pt.y.d0 - new_y.d0,
+        d1=x_diff_slope.d1 - pt.y.d1 - new_y.d1,
+        d2=x_diff_slope.d2 - pt.y.d2 - new_y.d2))
+
+    return (EcPoint(new_x, new_y))
+end
+
+# Adds two points on the elliptic curve.
+# Assumption: pt0.x != pt1.x (however, pt0 = pt1 = 0 is allowed).
+# Note that this means that the function cannot be used if pt0 = pt1
+# (use ec_double() in this case) or pt0 = -pt1 (the result is 0 in this case).
+func fast_ec_add{range_check_ptr}(pt0 : EcPoint, pt1 : EcPoint) -> (res : EcPoint):
+    if pt0.x.d0 == 0:
+        if pt0.x.d1 == 0:
+            if pt0.x.d2 == 0:
+                return (pt1)
+            end
+        end
+    end
+    if pt1.x.d0 == 0:
+        if pt1.x.d1 == 0:
+            if pt1.x.d2 == 0:
+                return (pt0)
+            end
+        end
+    end
+
+    let (slope : BigInt3) = compute_slope(pt0, pt1)
+    let (slope_sqr : UnreducedBigInt3) = unreduced_sqr(slope)
+
+    %{
+        from starkware.cairo.common.cairo_secp.secp_utils import SECP_P, pack
+
+        slope = pack(ids.slope, PRIME)
+        x0 = pack(ids.pt0.x, PRIME)
+        x1 = pack(ids.pt1.x, PRIME)
+        y0 = pack(ids.pt0.y, PRIME)
+
+        value = new_x = (pow(slope, 2, SECP_P) - x0 - x1) % SECP_P
+    %}
+    let (new_x : BigInt3) = nondet_bigint3()
+
+    %{ value = new_y = (slope * (x0 - new_x) - y0) % SECP_P %}
+    let (new_y : BigInt3) = nondet_bigint3()
+
+    verify_zero(
+        UnreducedBigInt3(
+        d0=slope_sqr.d0 - new_x.d0 - pt0.x.d0 - pt1.x.d0,
+        d1=slope_sqr.d1 - new_x.d1 - pt0.x.d1 - pt1.x.d1,
+        d2=slope_sqr.d2 - new_x.d2 - pt0.x.d2 - pt1.x.d2))
+
+    let (x_diff_slope : UnreducedBigInt3) = unreduced_mul(
+        BigInt3(d0=pt0.x.d0 - new_x.d0, d1=pt0.x.d1 - new_x.d1, d2=pt0.x.d2 - new_x.d2), slope)
+
+    verify_zero(
+        UnreducedBigInt3(
+        d0=x_diff_slope.d0 - pt0.y.d0 - new_y.d0,
+        d1=x_diff_slope.d1 - pt0.y.d1 - new_y.d1,
+        d2=x_diff_slope.d2 - pt0.y.d2 - new_y.d2))
+
+    return (EcPoint(new_x, new_y))
+end
+
+# Same as fast_ec_add, except that the cases pt0 = ±pt1 are supported.
+func ec_add{range_check_ptr}(pt0 : EcPoint, pt1 : EcPoint) -> (res : EcPoint):
+    let x_diff = BigInt3(d0=pt0.x.d0 - pt1.x.d0, d1=pt0.x.d1 - pt1.x.d1, d2=pt0.x.d2 - pt1.x.d2)
+    let (same_x : felt) = is_zero(x_diff)
+    if same_x == 0:
+        # pt0.x != pt1.x so we can use fast_ec_add.
+        return fast_ec_add(pt0, pt1)
+    end
+
+    # We have pt0.x = pt1.x. This implies pt0.y = ±pt1.y.
+    # Check whether pt0.y = -pt1.y.
+    let y_sum = BigInt3(d0=pt0.y.d0 + pt1.y.d0, d1=pt0.y.d1 + pt1.y.d1, d2=pt0.y.d2 + pt1.y.d2)
+    let (opposite_y : felt) = is_zero(y_sum)
+    if opposite_y != 0:
+        # pt0.y = -pt1.y.
+        # Note that the case pt0 = pt1 = 0 falls into this branch as well.
+        let ZERO_POINT = EcPoint(BigInt3(0, 0, 0), BigInt3(0, 0, 0))
+        return (ZERO_POINT)
+    else:
+        # pt0.y = pt1.y.
+        return ec_double(pt0)
+    end
+end
+
+# Given 0 <= m < 250, a scalar and a point on the elliptic curve, pt,
+# verifies that 0 <= scalar < 2**m and returns (2**m * pt, scalar * pt).
+func ec_mul_inner{range_check_ptr}(pt : EcPoint, scalar : felt, m : felt) -> (
+        pow2 : EcPoint, res : EcPoint):
+    if m == 0:
+        assert scalar = 0
+        let ZERO_POINT = EcPoint(BigInt3(0, 0, 0), BigInt3(0, 0, 0))
+        return (pow2=pt, res=ZERO_POINT)
+    end
+
+    alloc_locals
+    let (double_pt : EcPoint) = ec_double(pt)
+    %{ memory[ap] = (ids.scalar % PRIME) % 2 %}
+    jmp odd if [ap] != 0; ap++
+    return ec_mul_inner(pt=double_pt, scalar=scalar / 2, m=m - 1)
+
+    odd:
+    let (local inner_pow2 : EcPoint, inner_res : EcPoint) = ec_mul_inner(
+        pt=double_pt, scalar=(scalar - 1) / 2, m=m - 1)
+    # Here inner_res = (scalar - 1) / 2 * double_pt = (scalar - 1) * pt.
+    # Assume pt != 0 and that inner_res = ±pt. We obtain (scalar - 1) * pt = ±pt =>
+    # scalar - 1 = ±1 (mod N) => scalar = 0 or 2.
+    # In both cases (scalar - 1) / 2 cannot be in the range [0, 2**(m-1)), so we get a
+    # contradiction.
+    let (res : EcPoint) = fast_ec_add(pt0=pt, pt1=inner_res)
+    return (pow2=inner_pow2, res=res)
+end
+
+func ec_mul{range_check_ptr}(pt : EcPoint, scalar : BigInt3) -> (res : EcPoint):
+    alloc_locals
+    let (pow2_0 : EcPoint, local res0 : EcPoint) = ec_mul_inner(pt, scalar.d0, 86)
+    let (pow2_1 : EcPoint, local res1 : EcPoint) = ec_mul_inner(pow2_0, scalar.d1, 86)
+    let (_, local res2 : EcPoint) = ec_mul_inner(pow2_1, scalar.d2, 84)
+    let (res : EcPoint) = ec_add(res0, res1)
+    let (res : EcPoint) = ec_add(res, res2)
+    return (res)
+end

--- a/contracts/secp/secp_field.cairo
+++ b/contracts/secp/secp_field.cairo
@@ -1,0 +1,103 @@
+from contracts.secp.bigint import BASE, BigInt3, UnreducedBigInt3, nondet_bigint3
+from contracts.secp.secp_def import SECP_REM
+
+# Multiplies two values modulo the secp256k1 prime.
+# The returned limbs may be above 3 * BASE.
+#
+# If each of the input limbs is in the range (-x, x), the result's limbs are guaranteed to be
+# in the range (-x**2 * (2 ** 35.01), x**2 * (2 ** 35.01)).
+#
+# This means that if unreduced_mul is called on the result of nondet_bigint3, or the difference
+# between two such results, we have:
+#   Soundness guarantee: the limbs are in the range (-2**208.6, 2**208.6).
+#   Completeness guarantee: the limbs are in the range (-2**207.01, 2**207.01).
+func unreduced_mul(a : BigInt3, b : BigInt3) -> (res_low : UnreducedBigInt3):
+    # The result of the product is:
+    #   sum_{i, j} a.d_i * b.d_j * BASE**(i + j)
+    # Since we are computing it mod secp256k1_prime, we replace the term
+    #   a.d_i * b.d_j * BASE**(i + j)
+    # where i + j >= 3 with
+    #   a.d_i * b.d_j * BASE**(i + j - 3) * 4 * SECP_REM
+    # since BASE ** 3 = 4 * SECP_REM (mod secp256k1_prime).
+    return (
+        UnreducedBigInt3(
+        d0=a.d0 * b.d0 + (a.d1 * b.d2 + a.d2 * b.d1) * (4 * SECP_REM),
+        d1=a.d0 * b.d1 + a.d1 * b.d0 + (a.d2 * b.d2) * (4 * SECP_REM),
+        d2=a.d0 * b.d2 + a.d1 * b.d1 + a.d2 * b.d0))
+end
+
+# Computes the square of the given value modulo the secp256k1 prime.
+# It has the same guarantees as in unreduced_mul(a, a).
+func unreduced_sqr(a : BigInt3) -> (res_low : UnreducedBigInt3):
+    tempvar twice_d0 = a.d0 * 2
+    return (
+        UnreducedBigInt3(
+        d0=a.d0 * a.d0 + (a.d1 * a.d2) * (2 * 4 * SECP_REM),
+        d1=twice_d0 * a.d1 + (a.d2 * a.d2) * (4 * SECP_REM),
+        d2=twice_d0 * a.d2 + a.d1 * a.d1))
+end
+
+# Verifies that the given unreduced value is equal to zero modulo the secp256k1 prime.
+# Completeness assumption: val's limbs are in the range (-2**210.99, 2**210.99).
+# Soundness assumption: val's limbs are in the range (-2**250, 2**250).
+func verify_zero{range_check_ptr}(val : UnreducedBigInt3):
+    let q = [ap]
+    %{
+        from starkware.cairo.common.cairo_secp.secp_utils import SECP_P
+        q, r = divmod(pack(ids.val, PRIME), SECP_P)
+        assert r == 0, f"verify_zero: Invalid input {ids.val.d0, ids.val.d1, ids.val.d2}."
+        ids.q = q % PRIME
+    %}
+    let q_biased = [ap + 1]
+    q_biased = q + 2 ** 127; ap++
+    [range_check_ptr] = q_biased; ap++
+
+    tempvar r1 = (val.d0 + q * SECP_REM) / BASE
+    assert [range_check_ptr + 1] = r1 + 2 ** 127
+    # This implies r1 * BASE = val.d0 + q * SECP_REM (as integers).
+
+    tempvar r2 = (val.d1 + r1) / BASE
+    assert [range_check_ptr + 2] = r2 + 2 ** 127
+    # This implies r2 * BASE = val.d1 + r1 (as integers).
+    # Therefore, r2 * BASE**2 = val.d1 * BASE + r1 * BASE.
+
+    assert val.d2 = q * (BASE / 4) - r2
+    # This implies q * BASE / 4 = val.d2 + r2 (as integers).
+    # Therefore,
+    #   q * BASE**3 / 4 = val.d2 * BASE**2 + r2 * BASE ** 2 =
+    #   val.d2 * BASE**2 + val.d1 * BASE + r1 * BASE =
+    #   val.d2 * BASE**2 + val.d1 * BASE + val.d0 + q * SECP_REM =
+    #   val + q * SECP_REM.
+    # Hence, val = q * (BASE**3 / 4 - SECP_REM) = q * (2**256 - SECP_REM).
+
+    let range_check_ptr = range_check_ptr + 3
+    return ()
+end
+
+# Returns 1 if x == 0 (mod secp256k1_prime), and 0 otherwise.
+func is_zero{range_check_ptr}(x : BigInt3) -> (res : felt):
+    %{
+        from starkware.cairo.common.cairo_secp.secp_utils import SECP_P, pack
+        x = pack(ids.x, PRIME) % SECP_P
+    %}
+    if nondet %{ x == 0 %} != 0:
+        verify_zero(UnreducedBigInt3(d0=x.d0, d1=x.d1, d2=x.d2))
+        return (res=1)
+    end
+
+    %{
+        from starkware.cairo.common.cairo_secp.secp_utils import SECP_P
+        from starkware.python.math_utils import div_mod
+
+        value = x_inv = div_mod(1, x, SECP_P)
+    %}
+    let (x_inv) = nondet_bigint3()
+    let (x_x_inv) = unreduced_mul(x, x_inv)
+
+    # Check that x * x_inv = 1 to verify that x != 0.
+    verify_zero(UnreducedBigInt3(
+        d0=x_x_inv.d0 - 1,
+        d1=x_x_inv.d1,
+        d2=x_x_inv.d2))
+    return (res=0)
+end

--- a/contracts/test_contract.cairo
+++ b/contracts/test_contract.cairo
@@ -1,0 +1,6 @@
+%lang starknet
+
+@view
+func sum_three_values(v1: felt, v2:felt, v3: felt) -> (res: felt):
+    return (v1+v2+v3)
+end

--- a/contracts/web3_account.cairo
+++ b/contracts/web3_account.cairo
@@ -1,0 +1,106 @@
+# Based on Account from OpenZeppelin
+
+%lang starknet
+
+from starkware.cairo.common.registers import get_fp_and_pc
+from starkware.starknet.common.syscalls import get_contract_address
+from starkware.cairo.common.signature import verify_ecdsa_signature
+from starkware.cairo.common.cairo_builtins import HashBuiltin, SignatureBuiltin
+from starkware.starknet.common.syscalls import call_contract, get_caller_address, get_tx_signature
+from starkware.cairo.common.hash_state import (
+    hash_init, hash_finalize, hash_update, hash_update_single)
+from starkware.cairo.common.cairo_builtins import BitwiseBuiltin
+from starkware.cairo.common.math import assert_in_range, assert_not_equal, assert_not_zero
+from starkware.cairo.common.uint256 import Uint256
+from starkware.cairo.common.bitwise import bitwise_and
+from contracts.recover import calc_eth_address
+from contracts.eip712 import get_hash
+
+struct Message:
+    member sender : felt
+    member to : felt
+    member selector : felt
+    member calldata : felt*
+    member calldata_size : felt
+    member nonce : felt
+end
+
+@storage_var
+func current_nonce() -> (res : felt):
+end
+
+@storage_var
+func eth_address() -> (res : felt):
+end
+
+@view
+func get_nonce{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}() -> (res : felt):
+    let (res) = current_nonce.read()
+    return (res=res)
+end
+
+@constructor
+func constructor{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+        _eth_address : felt):
+    eth_address.write(_eth_address)
+    return ()
+end
+
+@external
+func execute{
+        syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr,
+        ecdsa_ptr : SignatureBuiltin*, bitwise_ptr : BitwiseBuiltin*}(
+        to : felt, selector : felt, calldata_len : felt, calldata : felt*, nonce : felt) -> (
+        response_len : felt, response : felt*):
+    alloc_locals
+
+    let (_address) = get_contract_address()
+    let (_current_nonce) = current_nonce.read()
+
+    # validate nonce
+    assert _current_nonce = nonce
+
+    local message : Message = Message(
+        _address,
+        to,
+        selector,
+        calldata,
+        calldata_size=calldata_len,
+        _current_nonce
+        )
+
+    validate_signature(message)
+
+    # bump nonce
+    current_nonce.write(_current_nonce + 1)
+
+    # execute call
+    let response = call_contract(
+        contract_address=message.to,
+        function_selector=message.selector,
+        calldata_size=message.calldata_size,
+        calldata=message.calldata)
+
+    return (response_len=response.retdata_size, response=response.retdata)
+end
+
+func validate_signature{
+        syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr,
+        ecdsa_ptr : SignatureBuiltin*, bitwise_ptr : BitwiseBuiltin*
+}(message : Message) -> ():
+    alloc_locals
+    let (signature_len, signature) = get_tx_signature()
+    assert signature_len = 5
+
+    let v = signature[0]
+    let r = Uint256(signature[1], signature[2])
+    let s = Uint256(signature[3], signature[4])
+    let (hash) = get_hash(
+        message.to, message.selector, message.calldata_size, message.calldata, message.nonce
+    )
+    let (address) = calc_eth_address(hash, v, r, s)
+    let (stored) = eth_address.read()
+    assert stored = address
+
+    return ()
+end


### PR DESCRIPTION
Please note that all contracts from `contracts/secp` are copied from https://github.com/starkware-libs/cairo-examples/tree/master/secp with only `mul_s_inv` edited to accept modulo param.